### PR TITLE
fixed message 22 ownershign to0d bstr encoding issue

### DIFF
--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/UntrustedRendezvousAcceptFunction.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/UntrustedRendezvousAcceptFunction.java
@@ -5,12 +5,12 @@ package org.fidoalliance.fdo.protocol;
 
 import java.io.IOException;
 import org.fidoalliance.fdo.protocol.dispatch.RendezvousAcceptFunction;
-import org.fidoalliance.fdo.protocol.message.To0OwnerSign;
+import org.fidoalliance.fdo.protocol.message.OwnershipVoucher;
 
 public class UntrustedRendezvousAcceptFunction implements RendezvousAcceptFunction {
 
   @Override
-  public Boolean apply(To0OwnerSign to0OwnerSign) throws IOException {
+  public Boolean apply(OwnershipVoucher voucher) throws IOException {
     return true;
   }
 }

--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/db/TrustedRendezvousAcceptFunction.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/db/TrustedRendezvousAcceptFunction.java
@@ -11,9 +11,7 @@ import java.io.IOException;
 import java.security.PublicKey;
 import java.util.ArrayList;
 import java.util.Base64;
-import java.util.Date;
 import java.util.List;
-import org.bouncycastle.util.encoders.Hex;
 import org.fidoalliance.fdo.protocol.Config;
 import org.fidoalliance.fdo.protocol.Mapper;
 import org.fidoalliance.fdo.protocol.dispatch.CryptoService;
@@ -26,7 +24,6 @@ import org.fidoalliance.fdo.protocol.message.OwnershipVoucher;
 import org.fidoalliance.fdo.protocol.message.OwnershipVoucherEntries;
 import org.fidoalliance.fdo.protocol.message.OwnershipVoucherEntryPayload;
 import org.fidoalliance.fdo.protocol.message.OwnershipVoucherHeader;
-import org.fidoalliance.fdo.protocol.message.To0OwnerSign;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 
@@ -53,7 +50,7 @@ public class TrustedRendezvousAcceptFunction implements RendezvousAcceptFunction
   }
 
   @Override
-  public Boolean apply(To0OwnerSign to0OwnerSign) throws IOException {
+  public Boolean apply(OwnershipVoucher voucher) throws IOException {
 
     boolean trusted = false;
     Session session = HibernateUtil.getSessionFactory().openSession();
@@ -67,9 +64,9 @@ public class TrustedRendezvousAcceptFunction implements RendezvousAcceptFunction
       TypedQuery<AllowDenyList> allQuery = session.createQuery(all);
 
       OwnershipVoucherHeader header = Mapper.INSTANCE.readValue(
-          to0OwnerSign.getTo0d().getVoucher().getHeader(), OwnershipVoucherHeader.class);
+          voucher.getHeader(), OwnershipVoucherHeader.class);
       String uuid = header.getGuid().toString();
-      List<String> hashes = getKeyHashes(to0OwnerSign.getTo0d().getVoucher());
+      List<String> hashes = getKeyHashes(voucher);
 
       //look for allowed
       for (AllowDenyList adList : allQuery.getResultList()) {

--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/dispatch/RendezvousAcceptFunction.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/dispatch/RendezvousAcceptFunction.java
@@ -5,8 +5,8 @@ package org.fidoalliance.fdo.protocol.dispatch;
 
 import java.io.IOException;
 import org.apache.commons.lang3.function.FailableFunction;
-import org.fidoalliance.fdo.protocol.message.To0OwnerSign;
+import org.fidoalliance.fdo.protocol.message.OwnershipVoucher;
 
 public interface RendezvousAcceptFunction
-    extends FailableFunction<To0OwnerSign, Boolean, IOException> {
+    extends FailableFunction<OwnershipVoucher, Boolean, IOException> {
 }

--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/message/To0OwnerSign2.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/message/To0OwnerSign2.java
@@ -13,16 +13,16 @@ import org.fidoalliance.fdo.protocol.serialization.GenericArraySerializer;
 @JsonFormat(shape = JsonFormat.Shape.ARRAY)
 @JsonPropertyOrder({"to0d", "to1d"})
 @JsonSerialize(using = GenericArraySerializer.class)
-public class To0OwnerSign {
+public class To0OwnerSign2 {
 
   @JsonProperty("to0d")
-  private byte[] to0d;
+  private To0d to0d;
 
   @JsonProperty("to1d")
   private CoseSign1 to1d;
 
   @JsonIgnore
-  public byte[] getTo0d() {
+  public To0d getTo0d() {
     return to0d;
   }
 
@@ -32,7 +32,7 @@ public class To0OwnerSign {
   }
 
   @JsonIgnore
-  public void setTo0d(byte[] to0d) {
+  public void setTo0d(To0d to0d) {
     this.to0d = to0d;
   }
 
@@ -41,3 +41,4 @@ public class To0OwnerSign {
     this.to1d = to1d;
   }
 }
+


### PR DESCRIPTION
5.3.3. TO0.OwnerSign, Type 22 tod0 is supposed to be encoded as a bstr.  RV server has been updated to handle both non compliant to0d as an array as well as spec compliant to0d encoded as a bstr.  Owner has been updated to always send spec compliant to0d encoded as a bstr.  Devices are unaffected.  