### PR TITLE
Defaulting MariaDB docker image to 10.11.4

### DIFF
--- a/component-samples/demo/db/docker-compose.yml
+++ b/component-samples/demo/db/docker-compose.yml
@@ -7,7 +7,7 @@ version: "3.3"
 services:
 
   fdo-db:
-    image: mariadb
+    image: mariadb:10.11.4
     restart: always
     ports:
       - 3306:3306   


### PR DESCRIPTION
  Defaulting MariaDB docker image to 10.11.4.