### PR TITLE
Update to command generating random password in keys_gen.sh

### DIFF
--- a/component-samples/demo/scripts/keys_gen.sh
+++ b/component-samples/demo/scripts/keys_gen.sh
@@ -51,8 +51,8 @@ gen_credentials()
 api_user='C=US, ST=OR, L=Hillsboro, O=LF Edge, OU=FDO project, CN=apiUser'
 db_user=root
 api_pass=default
-db_password=`openssl rand --base64 12 | tr -dc 0-9A-Za-z`
-encrypt_password=`openssl rand --base64 12 | tr -dc 0-9A-Za-z`
+db_password=`openssl rand -base64 12 | tr -dc 0-9A-Za-z`
+encrypt_password=`openssl rand -base64 12 | tr -dc 0-9A-Za-z`
 ssl_password=
 
 
@@ -68,7 +68,7 @@ echo "ssl_password=$ssl_password" >> service.env
 echo "api_user=$api_user" >> service.env
 echo "useSSL=true" >> service.env
 echo "requireSSL=true" >> service.env
-echo -n `openssl rand --base64 12 | tr -dc 0-9A-Za-z` > db_password.txt
+echo -n `openssl rand -base64 12 | tr -dc 0-9A-Za-z` > db_password.txt
 
 mkdir -p secrets
 touch ./secrets/api-user.pem


### PR DESCRIPTION
**Bug Description**
component-samples/demo/scripts/keys_gen.sh is used to generate environmental variables and secrets folder to store client  and server key pairs. One of the command `openssl rand --base64 12` in the shell script is used to generate db_password and encrypt_password. This is incorrect way of using it to generate password, the correct way is `openssl rand -base64 12`

**To Reproduce**
Steps to reproduce the behavior:
1. Go to 'component-samples/demo/scripts/'
2. Click on 'keys_gen.sh'
3. Scroll down to 'line no 54, 55, 71'
4. change `openssl rand --base64 12 | tr -dc 0-9A-Za-z` to `openssl rand -base64 12 | tr -dc 0-9A-Za-z`