### PR TITLE
[Fixed] Fuzzing TO0 message 22 issues

### DIFF
--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/StandardMessageDispatcher.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/StandardMessageDispatcher.java
@@ -82,6 +82,7 @@ import org.fidoalliance.fdo.protocol.message.OwnershipVoucherHeader;
 import org.fidoalliance.fdo.protocol.message.ProtocolVersion;
 import org.fidoalliance.fdo.protocol.message.PublicKeyEncoding;
 import org.fidoalliance.fdo.protocol.message.PublicKeyType;
+import org.fidoalliance.fdo.protocol.message.RendezvousConstant;
 import org.fidoalliance.fdo.protocol.message.RendezvousDirective;
 import org.fidoalliance.fdo.protocol.message.RendezvousInfo;
 import org.fidoalliance.fdo.protocol.message.RendezvousInstruction;
@@ -558,7 +559,7 @@ public class StandardMessageDispatcher implements MessageDispatcher {
 
         if (variable == RendezvousVariable.DNS) {
           dns = Mapper.INSTANCE.readValue(instruction.getValue(), String.class);
-          if (variable.toInteger() != 5 || dns.isEmpty() || dns == null) {
+          if (variable.toInteger() != RendezvousConstant.DNS || dns.isEmpty() || dns == null) {
             logger.info("Invalid RVDNS value in OV Header, moving to next instruction");
             isValidDirective = false;
             break;
@@ -567,7 +568,7 @@ public class StandardMessageDispatcher implements MessageDispatcher {
 
         if (variable == RendezvousVariable.DEV_PORT) {
           devPort = Mapper.INSTANCE.readValue(instruction.getValue(), Integer.class);
-          if (variable.toInteger() != 3 || devPort == null) {
+          if (variable.toInteger() != RendezvousConstant.DEV_PORT || devPort == null) {
             logger.info("Invalid RVDevPort value in OV Header, moving to next instruction");
             isValidDirective = false;
             break;
@@ -577,7 +578,7 @@ public class StandardMessageDispatcher implements MessageDispatcher {
         if (variable == RendezvousVariable.PROTOCOL) {
           RendezvousProtocol rvp = Mapper.INSTANCE.readValue(instruction.getValue(),
                 RendezvousProtocol.class);
-          if (variable.toInteger() != 12 || rvp.toString().isEmpty() || rvp == null) {
+          if (variable.toInteger() != RendezvousConstant.PROTOCOL || rvp.toString().isEmpty() || rvp == null) {
             logger.info("Invalid RVProtocol value in OV Header, moving to next instruction");
             isValidDirective = false;
             break;
@@ -586,7 +587,7 @@ public class StandardMessageDispatcher implements MessageDispatcher {
 
         if (variable == RendezvousVariable.OWNER_PORT) {
           ownerPort = Mapper.INSTANCE.readValue(instruction.getValue(), Integer.class);
-          if (variable.toInteger() != 4 || ownerPort == null) {
+          if (variable.toInteger() != RendezvousConstant.OWNER_PORT || ownerPort == null) {
             logger.info("Invalid RVOwnerPort value in OV Header, moving to next instruction");
             isValidDirective = false;
             break;

--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/StandardMessageDispatcher.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/StandardMessageDispatcher.java
@@ -584,7 +584,7 @@ public class StandardMessageDispatcher implements MessageDispatcher {
       isValidRVinfo |= isValidDirective;
     }
 
-    if(!isValidRVinfo){
+    if (!isValidRVinfo) {
       throw new InvalidMessageException("Invalid RendezvousInfo in OV Header");
     }
 

--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/StandardMessageDispatcher.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/StandardMessageDispatcher.java
@@ -578,7 +578,8 @@ public class StandardMessageDispatcher implements MessageDispatcher {
         if (variable == RendezvousVariable.PROTOCOL) {
           RendezvousProtocol rvp = Mapper.INSTANCE.readValue(instruction.getValue(),
                 RendezvousProtocol.class);
-          if (variable.toInteger() != RendezvousConstant.PROTOCOL || rvp.toString().isEmpty() || rvp == null) {
+          if (variable.toInteger() != RendezvousConstant.PROTOCOL || rvp.toString().isEmpty()
+                  || rvp == null) {
             logger.info("Invalid RVProtocol value in OV Header, moving to next instruction");
             isValidDirective = false;
             break;

--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/StandardMessageDispatcher.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/StandardMessageDispatcher.java
@@ -543,34 +543,49 @@ public class StandardMessageDispatcher implements MessageDispatcher {
     RendezvousInfo rvInfo = ovHeader.getRendezvousInfo();
     LinkedList<RendezvousDirective> directives = rvInfo;
 
+    boolean isValidRVinfo = false;
     for (RendezvousDirective directive : directives) {
       LinkedList<RendezvousInstruction> instructions = directive;
+      boolean isValidDirective = true;
       for (RendezvousInstruction instruction : instructions) {
 
         if (instruction.getVariable() == RendezvousVariable.DNS) {
           if (ByteBuffer.wrap(instruction.getValue()).getInt() != 5) {
-            throw new InvalidMessageException("Invalid RVDNS value in OV Header");
+            logger.info("Invalid RVDNS value in OV Header, moving to next instruction");
+            isValidDirective = false;
+            break;
           }
         }
 
         if (instruction.getVariable() == RendezvousVariable.DEV_PORT) {
           if (ByteBuffer.wrap(instruction.getValue()).getInt() != 3) {
-            throw new InvalidMessageException("Invalid RVDevPort value in OV Header");
+            logger.info("Invalid RVDevPort value in OV Header, moving to next instruction");
+            isValidDirective = false;
+            break;
           }
         }
 
         if (instruction.getVariable() == RendezvousVariable.PROTOCOL) {
           if (ByteBuffer.wrap(instruction.getValue()).getInt() != 12) {
-            throw new InvalidMessageException("Invalid RVProtocol value in OV Header");
+            logger.info("Invalid RVProtocol value in OV Header, moving to next instruction");
+            isValidDirective = false;
+            break;
           }
         }
 
         if (instruction.getVariable() == RendezvousVariable.OWNER_PORT) {
           if (ByteBuffer.wrap(instruction.getValue()).getInt() != 4) {
-            throw new InvalidMessageException("Invalid RVOwnerPort value in OV Header");
+            logger.info("Invalid RVOwnerPort value in OV Header, moving to next instruction");
+            isValidDirective = false;
+            break;
           }
         }
       }
+      isValidRVinfo |= isValidDirective;
+    }
+
+    if(!isValidRVinfo){
+      throw new InvalidMessageException("Invalid RendezvousInfo in OV Header");
     }
 
     PublicKeyEncoding mfgPubKeyEnc = ovHeader.getPublicKey().getEnc();

--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/StandardMessageDispatcher.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/StandardMessageDispatcher.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Date;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import org.apache.commons.codec.binary.Hex;
@@ -535,24 +536,37 @@ public class StandardMessageDispatcher implements MessageDispatcher {
       throw new InvalidMessageException("Invalid Protocol Version should only accept 101");
     }
 
-    RendezvousInstruction rvInstructionDns = ovHeader.getRendezvousInfo().get(0).get(0);
-    if (ByteBuffer.wrap(rvInstructionDns.getValue()).getInt() != 5) {
-      throw new InvalidMessageException("Invalid RVDNS value in OV Header");
-    }
+    RendezvousInfo rvInfo = ovHeader.getRendezvousInfo();
+    LinkedList<RendezvousDirective> directives = rvInfo;
 
-    RendezvousInstruction rvInstructionDevPort = ovHeader.getRendezvousInfo().get(0).get(1);
-    if (ByteBuffer.wrap(rvInstructionDevPort.getValue()).getInt() != 3) {
-      throw new InvalidMessageException("Invalid RVDevPort value in OV Header");
-    }
+    for (RendezvousDirective directive : directives) {
+      LinkedList<RendezvousInstruction> instructions = directive;
+      for (RendezvousInstruction instruction : instructions) {
 
-    RendezvousInstruction rvInstructionProtocol = ovHeader.getRendezvousInfo().get(0).get(2);
-    if (ByteBuffer.wrap(rvInstructionProtocol.getValue()).getInt() != 12) {
-      throw new InvalidMessageException("Invalid RVProtocol value in OV Header");
-    }
+        if (instruction.getVariable() == RendezvousVariable.DNS) {
+          if (ByteBuffer.wrap(instruction.getValue()).getInt() != 5) {
+            throw new InvalidMessageException("Invalid RVDNS value in OV Header");
+          }
+        }
 
-    RendezvousInstruction rvInstructionOwnerPort = ovHeader.getRendezvousInfo().get(0).get(4);
-    if (ByteBuffer.wrap(rvInstructionOwnerPort.getValue()).getInt() != 4) {
-      throw new InvalidMessageException("Invalid RVOwnerPort value in OV Header");
+        if (instruction.getVariable() == RendezvousVariable.DEV_PORT) {
+          if (ByteBuffer.wrap(instruction.getValue()).getInt() != 3) {
+            throw new InvalidMessageException("Invalid RVDevPort value in OV Header");
+          }
+        }
+
+        if (instruction.getVariable() == RendezvousVariable.PROTOCOL) {
+          if (ByteBuffer.wrap(instruction.getValue()).getInt() != 12) {
+            throw new InvalidMessageException("Invalid RVProtocol value in OV Header");
+          }
+        }
+
+        if (instruction.getVariable() == RendezvousVariable.OWNER_PORT) {
+          if (ByteBuffer.wrap(instruction.getValue()).getInt() != 4) {
+            throw new InvalidMessageException("Invalid RVOwnerPort value in OV Header");
+          }
+        }
+      }
     }
 
     PublicKeyEncoding mfgPubKeyEnc = ovHeader.getPublicKey().getEnc();

--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/message/RendezvousConstant.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/message/RendezvousConstant.java
@@ -2,21 +2,21 @@ package org.fidoalliance.fdo.protocol.message;
 
 public class RendezvousConstant {
 
-    public static final int DEV_ONLY = 0;
-    public static final int OWNER_ONLY = 1;
-    public static final int IP_ADDRESS = 2;
-    public static final int DEV_PORT = 3;
-    public static final int OWNER_PORT = 4;
-    public static final int DNS = 5;
-    public static final int SV_CERT_HASH = 6;
-    public static final int CL_CERT_HASH = 7;
-    public static final int USER_INPUT = 8;
-    public static final int WIFI_SSID = 9;
-    public static final int WIFI_PW = 10;
-    public static final int MEDIUM = 11;
-    public static final int PROTOCOL = 12;
-    public static final int DELAYSEC = 13;
-    public static final int BYPASS = 14;
-    public static final int EXT_RV = 15;
+  public static final int DEV_ONLY = 0;
+  public static final int OWNER_ONLY = 1;
+  public static final int IP_ADDRESS = 2;
+  public static final int DEV_PORT = 3;
+  public static final int OWNER_PORT = 4;
+  public static final int DNS = 5;
+  public static final int SV_CERT_HASH = 6;
+  public static final int CL_CERT_HASH = 7;
+  public static final int USER_INPUT = 8;
+  public static final int WIFI_SSID = 9;
+  public static final int WIFI_PW = 10;
+  public static final int MEDIUM = 11;
+  public static final int PROTOCOL = 12;
+  public static final int DELAYSEC = 13;
+  public static final int BYPASS = 14;
+  public static final int EXT_RV = 15;
 
 }

--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/message/RendezvousConstant.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/message/RendezvousConstant.java
@@ -1,6 +1,7 @@
 package org.fidoalliance.fdo.protocol.message;
 
 public class RendezvousConstant {
+
     public static final int DEV_ONLY = 0;
     public static final int OWNER_ONLY = 1;
     public static final int IP_ADDRESS = 2;

--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/message/RendezvousConstant.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/message/RendezvousConstant.java
@@ -1,0 +1,21 @@
+package org.fidoalliance.fdo.protocol.message;
+
+public class RendezvousConstant {
+    public static final int DEV_ONLY = 0;
+    public static final int OWNER_ONLY = 1;
+    public static final int IP_ADDRESS = 2;
+    public static final int DEV_PORT = 3;
+    public static final int OWNER_PORT = 4;
+    public static final int DNS = 5;
+    public static final int SV_CERT_HASH = 6;
+    public static final int CL_CERT_HASH = 7;
+    public static final int USER_INPUT = 8;
+    public static final int WIFI_SSID = 9;
+    public static final int WIFI_PW = 10;
+    public static final int MEDIUM = 11;
+    public static final int PROTOCOL = 12;
+    public static final int DELAYSEC = 13;
+    public static final int BYPASS = 14;
+    public static final int EXT_RV = 15;
+
+}

--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/serialization/RendezvousInstructionDeserializer.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/serialization/RendezvousInstructionDeserializer.java
@@ -45,14 +45,17 @@ public class RendezvousInstructionDeserializer extends StdDeserializer<Rendezvou
         if (subNode.isNull()) {
           throw new InvalidMessageException("expecting rv owner port value");
         }
+        return Mapper.INSTANCE.writeValue(subNode.intValue());
       case DEV_PORT:
         if (subNode.isNull()) {
           throw new InvalidMessageException("expecting rv dev port value");
         }
+        return Mapper.INSTANCE.writeValue(subNode.intValue());
       case PROTOCOL:
         if (subNode.isNull() || subNode.intValue() < 1 || subNode.intValue() > 2) {
           throw new InvalidMessageException("expecting rv protocol value 1 or 2");
         }
+        return Mapper.INSTANCE.writeValue(subNode.intValue());
       case MEDIUM:
       case DELAYSEC:
         return Mapper.INSTANCE.writeValue(subNode.intValue());

--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/serialization/RendezvousInstructionDeserializer.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/serialization/RendezvousInstructionDeserializer.java
@@ -34,28 +34,13 @@ public class RendezvousInstructionDeserializer extends StdDeserializer<Rendezvou
       case WIFI_SSID:
       case WIFI_PW:
       case DNS:
-        if (subNode.isNull()) {
-          throw new InvalidMessageException("expecting rv dns value");
-        }
         return Mapper.INSTANCE.writeValue(subNode.textValue());
       case IP_ADDRESS:
         return Mapper.INSTANCE.writeValue(
             InetAddress.getByName(subNode.textValue()).getAddress());
       case OWNER_PORT:
-        if (subNode.isNull()) {
-          throw new InvalidMessageException("expecting rv owner port value");
-        }
-        return Mapper.INSTANCE.writeValue(subNode.intValue());
       case DEV_PORT:
-        if (subNode.isNull()) {
-          throw new InvalidMessageException("expecting rv dev port value");
-        }
-        return Mapper.INSTANCE.writeValue(subNode.intValue());
       case PROTOCOL:
-        if (subNode.isNull() || subNode.intValue() < 1 || subNode.intValue() > 2) {
-          throw new InvalidMessageException("expecting rv protocol value 1 or 2");
-        }
-        return Mapper.INSTANCE.writeValue(subNode.intValue());
       case MEDIUM:
       case DELAYSEC:
         return Mapper.INSTANCE.writeValue(subNode.intValue());
@@ -104,7 +89,7 @@ public class RendezvousInstructionDeserializer extends StdDeserializer<Rendezvou
         rvi.setValue(getSubValue(variable, subNode));
       }
     }
-    // now check
+    //now check
 
     return rvi;
   }

--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/serialization/RendezvousInstructionDeserializer.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/serialization/RendezvousInstructionDeserializer.java
@@ -34,14 +34,25 @@ public class RendezvousInstructionDeserializer extends StdDeserializer<Rendezvou
       case WIFI_SSID:
       case WIFI_PW:
       case DNS:
+        if (subNode.isNull()) {
+          throw new InvalidMessageException("expecting rv dns value");
+        }
         return Mapper.INSTANCE.writeValue(subNode.textValue());
       case IP_ADDRESS:
-
         return Mapper.INSTANCE.writeValue(
             InetAddress.getByName(subNode.textValue()).getAddress());
       case OWNER_PORT:
+        if (subNode.isNull()) {
+          throw new InvalidMessageException("expecting rv owner port value");
+        }
       case DEV_PORT:
+        if (subNode.isNull()) {
+          throw new InvalidMessageException("expecting rv dev port value");
+        }
       case PROTOCOL:
+        if (subNode.isNull() || subNode.intValue() < 1 || subNode.intValue() > 2) {
+          throw new InvalidMessageException("expecting rv protocol value 1 or 2");
+        }
       case MEDIUM:
       case DELAYSEC:
         return Mapper.INSTANCE.writeValue(subNode.intValue());
@@ -90,7 +101,7 @@ public class RendezvousInstructionDeserializer extends StdDeserializer<Rendezvou
         rvi.setValue(getSubValue(variable, subNode));
       }
     }
-    //now check
+    // now check
 
     return rvi;
   }


### PR DESCRIPTION
1. **GUID Field in OV Header**: Prevents empty values in the GUID Field.

2. **Protocol Version in OV Header**: Ensures only "101" is accepted as the protocol version.

3. **RVDevPort Type in OV Header**: Accepts only "3" as the RVDevPort Type and checks for null values in RVDevPort Value.

4. **RVDNS Type in OV Header**: Accepts only "5" as the RVDNS Type and checks for null values in RVDNS Value.

5. **RVOwnerPort Type in OV Header**: Accepts only "4" as the RVOwnerPort Type and checks for null values in RVOwnerPort Value.

6. **RVProtocol Type in OV Header**: Accepts only "12" as the RVProtocol Type.

7. **RVProtocol Value in OV Header**: Accepts only "1" or "2" as the RVProtocol Value.

8. **Encoding of Mfg Pubkey in OV Header**: Ensures values like "+0.0" and "003" are not accepted.
