### PR TITLE
Fix maxMessageSize validation in StandardMessageDispatcher

### DIFF
--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/StandardMessageDispatcher.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/StandardMessageDispatcher.java
@@ -709,6 +709,9 @@ public class StandardMessageDispatcher implements MessageDispatcher {
     OnboardingConfig onboardConfig = new OnboardConfigSupplier().get();
     if (onboardConfig.getMaxMessageSize() != null) {
       int maxMessageSize = onboardConfig.getMaxMessageSize();
+      if (maxMessageSize != 0) {
+        throw new InvalidMessageException("Invalid maxMessageSize value should only accept 0");
+      }
       hdrPayload.setMaxMessageSize(maxMessageSize);
     } else {
       hdrPayload.setMaxMessageSize(0);

--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/StandardMessageDispatcher.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/StandardMessageDispatcher.java
@@ -709,8 +709,8 @@ public class StandardMessageDispatcher implements MessageDispatcher {
     OnboardingConfig onboardConfig = new OnboardConfigSupplier().get();
     if (onboardConfig.getMaxMessageSize() != null) {
       int maxMessageSize = onboardConfig.getMaxMessageSize();
-      if (maxMessageSize != 0) {
-        throw new InvalidMessageException("Invalid maxMessageSize value should only accept 0");
+      if (!(maxMessageSize == 0 || maxMessageSize >= 300)) {
+        throw new InvalidMessageException("Invalid maxMessageSize value");
       }
       hdrPayload.setMaxMessageSize(maxMessageSize);
     } else {


### PR DESCRIPTION
maxDeviceMessageSize field accepts random integer values, should only accept 0 or the minimum packet size(300) bytes