### PR TITLE
fix returns messages for serviceinfo

### DIFF
--- a/component-samples/device/src/main/java/org/fidoalliance/fdo/sample/FdoSimDownloadDeviceModule.java
+++ b/component-samples/device/src/main/java/org/fidoalliance/fdo/sample/FdoSimDownloadDeviceModule.java
@@ -19,6 +19,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.HashSet;
 import java.util.Set;
+
 import org.apache.commons.codec.binary.Hex;
 import org.fidoalliance.fdo.protocol.Config;
 import org.fidoalliance.fdo.protocol.InternalServerErrorException;
@@ -83,6 +84,7 @@ public class FdoSimDownloadDeviceModule implements ServiceInfoModule {
       case FdoSimDownloadOwnerModule.LENGTH:
         if (state.isActive()) {
           expectedLength = Mapper.INSTANCE.readValue(kvPair.getValue(), Integer.class);
+          bytesReceived = 0;
           logger.info("expected file length " + expectedLength);
         }
         break;
@@ -188,9 +190,35 @@ public class FdoSimDownloadDeviceModule implements ServiceInfoModule {
       throw new InternalServerErrorException(FdoSimDownloadOwnerModule.LENGTH + " not provided");
     }
 
+    if (bytesReceived == expectedLength) {
+      return;
+    }
+
     try (FileChannel channel = FileChannel.open(currentFile, StandardOpenOption.APPEND)) {
 
       bytesReceived += channel.write(ByteBuffer.wrap(data));
+
+      if (digest != null) {
+        digest.update(data);
+      }
+
+      int returnCode = -1;
+      if (bytesReceived == expectedLength) {
+
+        if (digest != null) {
+          byte[] checkSum = digest.digest();
+          if (ByteBuffer.wrap(checkSum).compareTo(ByteBuffer.wrap(expectedCheckSum)) == 0) {
+            returnCode = bytesReceived;
+          }
+        } else {
+          returnCode = bytesReceived;
+        }
+
+        ServiceInfoKeyValuePair kv = new ServiceInfoKeyValuePair();
+        kv.setKeyName(FdoSimDownloadOwnerModule.DONE);
+        kv.setValue(Mapper.INSTANCE.writeValue(returnCode));
+        queue.add(kv);
+      }
 
     } catch (IOException e) {
       throw new InternalServerErrorException(e);
@@ -199,6 +227,6 @@ public class FdoSimDownloadDeviceModule implements ServiceInfoModule {
     if (digest != null) {
       digest.update(data);
     }
-    
+
   }
 }

--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/StandardMessageDispatcher.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/StandardMessageDispatcher.java
@@ -1480,7 +1480,7 @@ public class StandardMessageDispatcher implements MessageDispatcher {
       }
     }
 
-    if (ownerInfo.isDone()) {
+    if (ownerInfo.isDone() && devInfo.getServiceInfo().isEmpty()) {
       To2Done done = storage.get(To2Done.class);
       response.setMsgType(MsgType.TO2_DONE);
       cipherText = Mapper.INSTANCE.writeValue(done);


### PR DESCRIPTION
Message 70 should not be sent until owner turns isDone and all pending deviceMessages have been sent - In additon, the download fsim must send done message