### PR TITLE
Fix getEnvValue to support multiple env variables

### DIFF
--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/Config.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/Config.java
@@ -292,7 +292,7 @@ public class Config {
               throw  new RuntimeException(e);
             }
           }
-          result = result.substring(0, start) + envValue + value.substring(end + 1);
+          result = result.substring(0, start) + envValue + result.substring(end + 1);
 
         } else {
           break;


### PR DESCRIPTION
Original value was used to resolve Env values. This would break when having multiple environment variable defined in the string value given to the `getEnvValue`.