### PR TITLE
Fix Diffie Hellman key exchange

### DIFF
--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/StandardCryptoService.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/StandardCryptoService.java
@@ -125,7 +125,7 @@ public class StandardCryptoService implements CryptoService {
     FipsDRBG.Builder drgbBldr = FipsDRBG.SHA512_HMAC.fromEntropySource(entSource)
             .setSecurityStrength(256)
             .setEntropyBitsRequired(256);
-    
+
     return drgbBldr.build(nonce, false);
 
   }
@@ -575,19 +575,9 @@ public class StandardCryptoService implements CryptoService {
 
         DiffieHellman.KeyExchange ke = DiffieHellman.buildKeyExchange(kexSuiteName, random);
         KexMessage msg = new KexMessage();
-        try {
-          msg.setMessage(ke.getMessage().toByteArray());
-          msg.setState(AnyType.fromObject(ke));
-          return msg;
-        } finally {
-          try {
-            ke.destroy();
-          } catch (DestroyFailedException e) {
-            // this should never happen
-            assert false;
-            throw new RuntimeException(e);
-          }
-        }
+        msg.setMessage(ke.getMessage().toByteArray());
+        msg.setState(AnyType.fromObject(ke));
+        return msg;
       default:
         throw new InvalidMessageException("invalid key exchange " + kexSuiteName);
     }

--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/StandardCryptoService.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/StandardCryptoService.java
@@ -726,8 +726,13 @@ public class StandardCryptoService implements CryptoService {
             ownState.getState().covertValue(DiffieHellman.KeyExchange.class);
 
         try {
-          return new KeyExchangeResult(
-              ke.computeSharedSecret(new BigInteger(1, message)).toByteArray(), new byte[0]);
+          byte[] shSe = ke.computeSharedSecret(new BigInteger(1, message)).toByteArray();
+          if (shSe[0] == 0x00) {
+            byte[] tmp = new byte[shSe.length - 1];
+            System.arraycopy(shSe, 1, tmp, 0, tmp.length);
+            shSe = tmp;
+          }
+          return new KeyExchangeResult(shSe, new byte[0]);
         } finally {
           try {
             ke.destroy();

--- a/protocol/src/main/java/org/fidoalliance/fdo/protocol/message/DiffieHellman.java
+++ b/protocol/src/main/java/org/fidoalliance/fdo/protocol/message/DiffieHellman.java
@@ -3,6 +3,7 @@
 
 package org.fidoalliance.fdo.protocol.message;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -85,6 +86,14 @@ public final class DiffieHellman {
     @JsonProperty("mySecret")
     private BigInteger mySecret;
 
+    @JsonCreator
+    private KeyExchange(@JsonProperty("myP") BigInteger p,
+        @JsonProperty("myG") BigInteger g, @JsonProperty("mySecret") BigInteger secret) {
+      myP = p;
+      myG = g;
+      mySecret = secret;
+    }
+
     @JsonIgnore
     private KeyExchange(BigInteger p, BigInteger g, int randomSizeInBits, SecureRandom random) {
       myP = p;
@@ -97,7 +106,6 @@ public final class DiffieHellman {
       return myG.modPow(mySecret, myP);
     }
 
-
     public BigInteger computeSharedSecret(BigInteger otherMessage) {
       return otherMessage.modPow(mySecret, myP);
     }
@@ -107,6 +115,7 @@ public final class DiffieHellman {
       mySecret = null;
     }
 
+    @JsonIgnore
     @Override
     public boolean isDestroyed() {
       return null == mySecret;


### PR DESCRIPTION
1. The device's secret gets set to null in an erroneous call to destroy before it is used to compute the shared secret, thus causing `modPow` to throw an exception.
2. The DiffieHellman.KeyExchange type cannot reconstruct itself from an `AnyType` without a `@JsonCreator`-annotated constructor.
3. The shared secret is sometimes 1 extra byte in length, due to the behavior of `BigInteger.toBytes()`. See https://stackoverflow.com/questions/24158629/biginteger-tobytearray-returns-purposeful-leading-zeros.