### PR TITLE
upgrade mysql and protobuf to fix vulnerability

### DIFF
--- a/component-samples/aio/pom.xml
+++ b/component-samples/aio/pom.xml
@@ -70,8 +70,8 @@
 
     <!-- https://mvnrepository.com/artifact/mysql/mysql-connector-java -->
     <dependency>
-      <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
+      <groupId>com.mysql</groupId>
+      <artifactId>mysql-connector-j</artifactId>
       <version>${mysql.version}</version>
     </dependency>
 
@@ -90,6 +90,16 @@
 
 
   </dependencies>
+  
+  <dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>4.28.2</version>
+        </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <build>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <!-- Database Client Version -->
     <h2db.version>2.2.224</h2db.version>
     <mariadb.version>3.0.5</mariadb.version>
-    <mysql.version>8.0.33</mysql.version>
+    <mysql.version>8.2.0</mysql.version>
     <postgresql.version>42.5.5</postgresql.version>
 
     <!-- Maven Version -->


### PR DESCRIPTION
This PR fix vulnerability in mysql-connector-j(https://github.com/advisories/GHSA-m6vm-37g8-gqvh) and protobuf-java(https://github.com/advisories/GHSA-735f-pc8j-v9w8).  #705

Mysql-connector-j 8.2.0 still brings in a vulnerable version of protobuf-java (3.21.9) as a transitive dependency.  Mysql-connector-j 9.1.0 includes a fixed version of protobuf-java but I am worried that upgrading to 9.x may introduce compatibility issues. Therefore this PR upgrades mysql-connector-j to 8.2.0 to fix MySQL-related vulnerabilities and explicitly sets protobuf-java to 4.28.2 to avoid the transitive vulnerability

![image](https://github.com/user-attachments/assets/3d194e53-3032-4da0-aec5-059375f0a326)
