### PR TITLE
Fix the CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -45,12 +45,13 @@ jobs:
           chmod -R 777 secrets/
           cp -r service.env secrets/ ../aio/
           cp -r secrets/ ../db/
+          echo "useSSL=false" >> ../aio/service.env
           sed -i '/<security-constraint>/,/<.security-constraint>/d' ../aio/WEB-INF/web.xml
           sed -i '/^innodb/d' ../db/custom/config-file.cnf
           cd ${{ github.workspace }}/test-fidoiot
           export TEST_DIR=$PWD
           cd binaries/pri-fidoiot/aio
-          docker compose up -d --build || docker-compose up -d --build
+          docker compose up -d --build
           cd ../../..
           sleep 10
           mvn clean test -Dgroups=fdo_pri_smoketest

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -49,6 +49,10 @@ jobs:
           sed -i '/^innodb/d' ../db/custom/config-file.cnf
           cd ${{ github.workspace }}/test-fidoiot
           export TEST_DIR=$PWD
+          cd binaries/pri-fidoiot/aio
+          docker compose up -d --build || docker-compose up -d --build
+          cd ../../..
+          sleep 10
           mvn clean test -Dgroups=fdo_pri_smoketest
       - name: archive artifacts
         uses: actions/upload-artifact@v4

--- a/component-samples/demo/aio/docker-compose.yml
+++ b/component-samples/demo/aio/docker-compose.yml
@@ -5,6 +5,24 @@ version: "3.3"
 
 services:
 
+  fdo-db:
+    image: mariadb:11.4.2
+    container_name: fdo-db
+    restart: always
+    ports:
+      - 3306:3306
+    environment:
+      - MARIADB_ROOT_PASSWORD_FILE=/run/secrets/db_password.txt
+      - MARIADB_DATABASE=emdb
+    secrets:
+      - ca-cert.pem
+      - server-cert.pem
+      - server-key.pem
+      - db_password.txt
+    volumes:
+      - ./app-data:/var/lib/mysql
+      - ./custom:/etc/mysql/conf.d
+
   pri-fdo-aio:
     image: pri-fdo-aio
     container_name: pri-fdo-aio
@@ -35,6 +53,9 @@ services:
     mem_limit: 500m
     mem_reservation: 200m
     cpu_shares: 1024
+    depends_on:
+      - fdo-db
+    command: sh -c "sleep 10 && java -jar /home/fdo/aio.jar"
 
 secrets:
   ca-cert.pem:
@@ -47,3 +68,4 @@ secrets:
     file: ./secrets/api-user.pem
   db_password.txt:
     file: ./secrets/db_password.txt
+    

--- a/component-samples/demo/aio/hibernate.cfg.xml
+++ b/component-samples/demo/aio/hibernate.cfg.xml
@@ -19,6 +19,9 @@
 	<property name="hibernate.connection.url">jdbc:mariadb://localhost:3306/fdo</property>
         -->
 
+        <!-- for maria databse -->
+        <property name="hibernate.connection.url">jdbc:mariadb://fdo-db:3306/emdb</property>
+
         <!-- show mysql queries output in console -->
         <property name="hibernate.show_sql">true</property>
 
@@ -35,6 +38,8 @@
         <!-- <property name="hibernate.dialect">org.hibernate.dialect.DerbyTenSevenDialect</property> -->
         <!-- for maria/mysql
         <property name="dialect">org.hibernate.dialect.MariaDBDialect</property> -->
+        <!-- for maria/mysql -->
+        <property name="dialect">org.hibernate.dialect.MariaDBDialect</property>
 
 
 

--- a/component-samples/demo/aio/hibernate.cfg.xml
+++ b/component-samples/demo/aio/hibernate.cfg.xml
@@ -36,8 +36,7 @@
 
 	<!-- for embedded database -->
         <!-- <property name="hibernate.dialect">org.hibernate.dialect.DerbyTenSevenDialect</property> -->
-        <!-- for maria/mysql
-        <property name="dialect">org.hibernate.dialect.MariaDBDialect</property> -->
+
         <!-- for maria/mysql -->
         <property name="dialect">org.hibernate.dialect.MariaDBDialect</property>
 

--- a/component-samples/demo/aio/service.yml
+++ b/component-samples/demo/aio/service.yml
@@ -1,7 +1,7 @@
 hibernate-properties:
   hibernate.connection.username: $(db_user)
   hibernate.connection.password: $(db_password)
-  hibernate.connection.url: jdbc:mariadb://host.docker.internal:3306/emdb?useSSL=$(useSSL)
+  hibernate.connection.url: jdbc:mariadb://fdo-db:3306/emdb?useSSL=false
   hibernate.connection.requireSSL: $(requireSSL)
   hibernate.connection.autoReconnect: true
   hibernate.dialect: org.hibernate.dialect.MariaDBDialect

--- a/component-samples/demo/aio/service.yml
+++ b/component-samples/demo/aio/service.yml
@@ -1,7 +1,7 @@
 hibernate-properties:
   hibernate.connection.username: $(db_user)
   hibernate.connection.password: $(db_password)
-  hibernate.connection.url: jdbc:mariadb://fdo-db:3306/emdb?useSSL=false
+  hibernate.connection.url: jdbc:mariadb://fdo-db:3306/emdb?useSSL=$(useSSL)
   hibernate.connection.requireSSL: $(requireSSL)
   hibernate.connection.autoReconnect: true
   hibernate.dialect: org.hibernate.dialect.MariaDBDialect


### PR DESCRIPTION
This PR fix CI.

Based on investigation, the main issue was that the AIO container could not start properly and failed to connect to MariaDB. This led to the PriSmokeTest not being executed under the correct prerequisites.

This PR updates the necessary configuration files to:

Ensure the AIO container starts successfully within the CI environment

Include a working MariaDB instance inside the AIO service network

Set up the database connection properly for the smoke tests

With these changes, PriSmokeTest can now run under the intended conditions, and CI completes successfully.

CI is passing reliably with this configuration.

<img width="1036" height="611" alt="image" src="https://github.com/user-attachments/assets/603c2901-1e5c-41f9-88e7-52e27187922b" />
